### PR TITLE
fixed no response issue in port scan command

### DIFF
--- a/rsyslog/configure_linux.sh
+++ b/rsyslog/configure_linux.sh
@@ -92,7 +92,7 @@ function validate_network_connectivity {
 	# Run tests nc OR netcat
 	if is_installed netcat || is_installed nc || is_installed nmap-ncat; then
 		log "INFO" "Checking if ${LISTENER_HOST} is reachable via ${LISTENER_PORT} port, using netcat. This may take some time...."
-		echo "test" | nc ${LISTENER_HOST} ${LISTENER_PORT}
+		echo "test" | nc -zv ${LISTENER_HOST} ${LISTENER_PORT}
 		status=$?
 	elif is_installed telnet; then
 		echo "-------------------------------------------"


### PR DESCRIPTION
**Issue Reproduce Environment:** 
Ubuntu `18.04`
Outgoing port `5000` was already open.

**Problem:**
While executing the script to setup the `rslog`, I encountered no response for minutes, at line where it scans the connectivity with `logz.io` server. It was stuck and not responding to any key press.

**Fix:**
added `-zv` attributes in `nc` command like: `nc -zv ...`